### PR TITLE
feature: 升級專案至 .NET 8 並更新相關套件

### DIFF
--- a/BuberDinner.Api/BuberDinner.Api.csproj
+++ b/BuberDinner.Api/BuberDinner.Api.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>3af776ca-3eb2-4771-89d0-2aa61dcb0c4f</UserSecretsId>

--- a/BuberDinner.Application/BuberDinner.Application.csproj
+++ b/BuberDinner.Application/BuberDinner.Application.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/BuberDinner.Contracts/BuberDinner.Contracts.csproj
+++ b/BuberDinner.Contracts/BuberDinner.Contracts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/BuberDinner.Domain/BuberDinner.Domain.csproj
+++ b/BuberDinner.Domain/BuberDinner.Domain.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/BuberDinner.Infrastructure/BuberDinner.Infrastructure.csproj
+++ b/BuberDinner.Infrastructure/BuberDinner.Infrastructure.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.23" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.20" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+	  <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
1. 將所有專案的目標框架從 `net6.0` 升級到 `net8.0`：
   - `BuberDinner.Api.csproj`
   - `BuberDinner.Application.csproj`
   - `BuberDinner.Contracts.csproj`
   - `BuberDinner.Domain.csproj`
   - `BuberDinner.Infrastructure.csproj`
2. 更新 `BuberDinner.Infrastructure.csproj` 中的 NuGet 套件版本：
   - `Microsoft.AspNetCore.Authentication.JwtBearer` 升級至 `8.0.20`
   - `Microsoft.Extensions.Configuration` 升級至 `8.0.0`
   - `Microsoft.Extensions.DependencyInjection.Abstractions` 保持在 `8.0.0`
   - `Microsoft.Extensions.Options.ConfigurationExtensions` 升級至 `8.0.0`
   - `System.IdentityModel.Tokens.Jwt` 升級至 `8.14.0`
3. 所有專案的 `PropertyGroup` 中保留以下屬性：
   - `Nullable` 設為 `enable`
   - `ImplicitUsings` 設為 `enable`
4. `BuberDinner.Infrastructure.csproj` 中保留對 `BuberDinner.Application` 的專案引用。